### PR TITLE
Update codigo_situacao3.smv

### DIFF
--- a/Codigo/codigo_situacao3.smv
+++ b/Codigo/codigo_situacao3.smv
@@ -27,7 +27,7 @@ TRANS
 
   -- reconstrução
   (pos_a = table1 & pos_b = table2 & clear_a & clear_b & size_a <= size_b) -> next(pos_a) = on_b;
-  (pos_c = table3 & pos_a = on_b & clear_c & clear_a & size_c <= size_a) -> next(pos_c) = on_a;
+  (pos_c = table3 & pos_a = on_b & clear_c & clear_a) -> next(pos_c) = on_a;
   (pos_d = table0 & pos_c = on_a & clear_d & clear_c & size_d <= size_c) -> next(pos_d) = on_c;
 
 DEFINE


### PR DESCRIPTION
oe, encontrei um ponto na modelagem da situação 3 que fazia o teste de atingibilidade "CTLSPEC EF goal" falhar, retornando FALSE. O problema é que o nosso estado final (goal) exige que o bloco C (tamanho 2) fosse colocado sobre o bloco A (tamanho 1). Aí essa restrição de estabilidade impedia esse movimento, pq 2≤1 é falso, aí é só mudar esse finalzinho